### PR TITLE
[TERRA-435] Add sonarqube to build.gradle

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,6 +10,7 @@ plugins {
     id 'com.github.davidmc24.gradle.plugin.avro' version '1.6.0'
     id 'com.github.spotbugs' version '5.0.13'
     id 'com.jfrog.artifactory' version '4.31.5'
+    id 'org.sonarqube' version '4.0.0.2929'
 }
 
 // If true, search local repository (~/.m2/repository/) first for dependencies.
@@ -47,6 +48,7 @@ apply from: "$gradleIncDir/dependency-locking.gradle"
 apply from: "$gradleIncDir/jacoco.gradle"
 apply from: "$gradleIncDir/javadoc.gradle"
 apply from: "$gradleIncDir/publishing.gradle"
+apply from: "$gradleIncDir/sonarqube.gradle"
 apply from: "$gradleIncDir/spotbugs.gradle"
 apply from: "$gradleIncDir/spotless.gradle"
 apply from: "$gradleIncDir/testing.gradle"

--- a/gradle/sonarqube.gradle
+++ b/gradle/sonarqube.gradle
@@ -1,0 +1,8 @@
+sonar {
+    properties {
+        property 'sonar.projectName', rootProject.name
+        property 'sonar.projectKey', 'DataBiosphere_' + rootProject.name
+        property 'sonar.organization', 'broad-databiosphere'
+        property 'sonar.host.url', 'https://sonarcloud.io'
+    }
+}


### PR DESCRIPTION
Add sonarqube to this repo
Based on https://github.com/DataBiosphere/terra-workspace-manager/pull/1039

Ref - https://dsp-security.broadinstitute.org/appsec-team-internal/appsec-team-internal/security-activities/sast-1

requires - https://github.com/broadinstitute/terraform-ap-deployments/pull/980