### PR TITLE
[BENCH-917] Forcing a bump in the org.apache.bcel:bcel version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,11 @@ plugins {
     id 'org.sonarqube' version '4.0.0.2929'
 }
 
+configurations.all {
+  // Bump required by CVE-2022-42920. This update will be released in spotbugs 4.7.4.
+  resolutionStrategy.force 'org.apache.bcel:bcel:6.6.1'
+}
+
 group = gradle.projectGroup
 
 project.ext {


### PR DESCRIPTION
Bumping the org.apache.bcel:bcel version from 6.5.0 to 6.6.1 for a security remediation. bcel is being brought in by spotbugs, but spotbugs hasn't released a new tag with the bump. 6.7.0 was released but it has a bug with spotbugs.

For more details:
https://github.com/spotbugs/spotbugs/discussions/2251 (Issue in spotbugs to bump the version for security reason).
https://github.com/spotbugs/spotbugs/commit/59eeb2d7e999b70f9bb1ff4639855a7742750eec (PR that bumps the version with no other changes)